### PR TITLE
always show table when no data

### DIFF
--- a/dist/ng-table.js
+++ b/dist/ng-table.js
@@ -1065,9 +1065,7 @@ function($scope, NgTableParams, $timeout, $parse, $compile, $attrs, $element, ng
     $scope.$watch('params.isDataReloadRequired()', onDataReloadStatusChange);
 
     this.compileDirectiveTemplates = function () {
-        var tableTemplate = $element.find('table').attr({
-          'ng-show':'$hasData'
-        });
+        var tableTemplate = $element.find('table');
 
         if (!$element.hasClass('os-table')) {
             compileNoDataTemplate($element);


### PR DESCRIPTION
### Root Cause

- 根据[这个bug](http://git.augmentum.com.cn/scrm/omnisocials-frontend/issues/169), `ng-table`没有数据时,依然需要让其显示表头.

### Solution

- 删掉没有数据时不显示表头的判断

### Related Backend MR

- N/A
